### PR TITLE
refresh_token进行储存reids

### DIFF
--- a/src/RedisHandler.php
+++ b/src/RedisHandler.php
@@ -36,6 +36,26 @@ class RedisHandler
         Redis::setex($cacheKey, $ttl, $token);
     }
 
+
+    /**
+     * @desc: 刷新存储的缓存令牌
+     * @param string $pre
+     * @param string $client
+     * @param string $uid
+     * @param int $ttl
+     * @param string $token
+     * @return void
+     */
+    public static function refreshToken(string $pre, string $client, string $uid, int $ttl, string $token): void
+    {
+        $cacheKey = $pre . $client . ':' . $uid;
+        $key = Redis::keys($cacheKey . '*');
+        if (!empty($key)) {
+            $ttl = Redis::ttl($cacheKey);
+        }
+        Redis::setex($cacheKey, $ttl, $token);
+    }
+
     /**
      * @desc: 检查设备缓存令牌
      * @param string $pre

--- a/src/config/plugin/tinywan/jwt/app.php
+++ b/src/config/plugin/tinywan/jwt/app.php
@@ -39,6 +39,9 @@ return [
         /** 缓存令牌前缀，默认 JWT:TOKEN: */
         'cache_token_pre' => 'JWT:TOKEN:',
 
+        /** 缓存刷新令牌前缀，默认 JWT:REFRESH_TOKEN: */
+        'cache_refresh_token_pre' => 'JWT:REFRESH_TOKEN:',
+
         /** 用户信息模型 */
         'user_model' => function ($uid) {
             return [];


### PR DESCRIPTION
1.把refresh_token进行存储，不进行存储，旧的refreh_toekn是可以依旧刷新的导致，单设备登录失效，两边同时登录，然后相互刷 
 新token
2刷新token中的 重新存储的cache_token_pre，我本地开发的时候，发现时间戳，并未过期自动删除，一直保留着然后一直在执行倒计时，我这里替换成了config中的access_exp