### PR TITLE
增加刷新令牌时extend数据的获取与传递

### DIFF
--- a/src/JwtToken.php
+++ b/src/JwtToken.php
@@ -89,16 +89,19 @@ class JwtToken
 
     /**
      * @desc: 刷新令牌
-     *
+     * @param array $_extend 拓展数据
      * @return array|string[]
      * @throws JwtTokenException
      */
-    public static function refreshToken(): array
+    public static function refreshToken(&$_extend = []): array
     {
         $token = self::getTokenFromHeaders();
         $config = self::_getConfig();
         try {
             $extend = self::verifyToken($token, self::REFRESH_TOKEN);
+            if (!empty($extend['extend'])){
+                $_extend = $extend['extend'];
+            }
         } catch (SignatureInvalidException $signatureInvalidException) {
             throw new JwtRefreshTokenExpiredException('刷新令牌无效',401021);
         } catch (BeforeValidException $beforeValidException) {


### PR DESCRIPTION
解决刷新令牌时 无法获取用户拓展信息
- 场景 验证用户是否有权限刷新(如被禁用)