### PR TITLE
修复ES系列和PS系列算法无法正常使用的问题并修正注释，仅提示已支持的算法

### DIFF
--- a/src/JwtToken.php
+++ b/src/JwtToken.php
@@ -324,19 +324,14 @@ class JwtToken
     private static function getPublicKey(string $algorithm, int $tokenType = self::ACCESS_TOKEN): string
     {
         $config = self::_getConfig();
-        switch ($algorithm) {
-            case 'HS256':
-                $key = self::ACCESS_TOKEN == $tokenType ? $config['access_secret_key'] : $config['refresh_secret_key'];
-                break;
-            case 'RS512':
-            case 'RS256':
-                $key = self::ACCESS_TOKEN == $tokenType ? $config['access_public_key'] : $config['refresh_public_key'];
-                break;
-            default:
-                $key = $config['access_secret_key'];
+
+        $isAccessToken = $tokenType === self::ACCESS_TOKEN;
+
+        if (in_array($algorithm, ['HS512', 'HS384', 'HS256'], true)) {
+            return $isAccessToken ? $config['access_secret_key'] : $config['refresh_secret_key'];
         }
 
-        return $key;
+        return $isAccessToken ? $config['access_public_key'] : $config['refresh_public_key'];
     }
 
     /**
@@ -347,19 +342,13 @@ class JwtToken
      */
     private static function getPrivateKey(array $config, int $tokenType = self::ACCESS_TOKEN): string
     {
-        switch ($config['algorithms']) {
-            case 'HS256':
-                $key = self::ACCESS_TOKEN == $tokenType ? $config['access_secret_key'] : $config['refresh_secret_key'];
-                break;
-            case 'RS512':
-            case 'RS256':
-                $key = self::ACCESS_TOKEN == $tokenType ? $config['access_private_key'] : $config['refresh_private_key'];
-                break;
-            default:
-                $key = $config['access_secret_key'];
+        $isAccessToken = $tokenType === self::ACCESS_TOKEN;
+
+        if (in_array($config['algorithms'], ['HS512', 'HS384', 'HS256'], true)) {
+            return $isAccessToken ? $config['access_secret_key'] : $config['refresh_secret_key'];
         }
 
-        return $key;
+        return $isAccessToken ? $config['access_private_key'] : $config['refresh_private_key'];
     }
 
     /**

--- a/src/config/plugin/tinywan/jwt/app.php
+++ b/src/config/plugin/tinywan/jwt/app.php
@@ -3,7 +3,7 @@
 return [
     'enable' => true,
     'jwt' => [
-        /** 算法类型 HS256、HS384、HS512、RS256、RS384、RS512、ES256、ES384、Ed25519 */
+        /** 算法类型 HS256、HS384、HS512、RS256、RS384、RS512、ES256、ES384、ES512、PS256、PS384、PS512 */
         'algorithms' => 'HS256',
 
         /** access令牌秘钥 */


### PR DESCRIPTION
ES系列和PS系列算法是需要公私钥签名的，但是原来的代码却错误的把私钥指向了SHA算法的access_secret_key配置项中，导致一直提示私钥不正确，完全无法使用。